### PR TITLE
chore: mark client as beta

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -4,7 +4,7 @@
   "product_documentation": "https://cloud.google.com/docs/games/products/",
   "client_documentation": "https://googleapis.dev/java/google-cloud-game-servers/latest/",
   "issue_tracker": "",
-  "release_level": "alpha",
+  "release_level": "beta",
   "language": "java",
   "repo": "googleapis/java-game-servers",
   "repo_short": "java-game-servers",

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Java 11 | [![Kokoro CI][kokoro-badge-image-5]][kokoro-badge-link-5]
 [kokoro-badge-link-4]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-game-servers/java8-win.html
 [kokoro-badge-image-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-game-servers/java11.svg
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-game-servers/java11.html
-[stability-image]: https://img.shields.io/badge/stability-alpha-orange
+[stability-image]: https://img.shields.io/badge/stability-beta-yellow
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-game-servers.svg
 [maven-version-link]: https://search.maven.org/search?q=g:com.google.cloud%20AND%20a:google-cloud-game-servers&core=gav
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication


### PR DESCRIPTION
The next release contains the beta client so we can mark this repo as beta.

Fixes #43
